### PR TITLE
Add sheet name to description, ignore empty string comparison

### DIFF
--- a/src/main/java/bad/robot/excel/matchers/CellInRowMatcher.java
+++ b/src/main/java/bad/robot/excel/matchers/CellInRowMatcher.java
@@ -18,6 +18,7 @@ package bad.robot.excel.matchers;
 
 import bad.robot.excel.cell.Cell;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
@@ -26,18 +27,20 @@ import static bad.robot.excel.matchers.CellType.adaptPoi;
 
 public class CellInRowMatcher extends TypeSafeDiagnosingMatcher<Row> {
 
+	private final Sheet sheet;
     private final Cell expected;
     private final int columnIndex;
     private final String coordinate;
 
-    private CellInRowMatcher(org.apache.poi.ss.usermodel.Cell expectedPoi) {
-        this.expected = adaptPoi(expectedPoi);
+    private CellInRowMatcher(Sheet sheet, org.apache.poi.ss.usermodel.Cell expectedPoi) {
+        this.sheet = sheet;
+		this.expected = adaptPoi(expectedPoi);
         this.coordinate = asExcelCoordinate(expectedPoi);
         this.columnIndex = expectedPoi.getColumnIndex();
     }
 
-    public static CellInRowMatcher hasSameCell(org.apache.poi.ss.usermodel.Cell expected) {
-        return new CellInRowMatcher(expected);
+    public static CellInRowMatcher hasSameCell(Sheet sheet, org.apache.poi.ss.usermodel.Cell expected) {
+        return new CellInRowMatcher(sheet, expected);
     }
 
     @Override
@@ -45,7 +48,8 @@ public class CellInRowMatcher extends TypeSafeDiagnosingMatcher<Row> {
         Cell actual = adaptPoi(row.getCell(columnIndex));
 
         if (!expected.equals(actual)) {
-            mismatch.appendText("cell at ").appendValue(coordinate).appendText(" contained ").appendValue(actual).appendText(" expected ").appendValue(expected);
+            mismatch.appendText("cell at ").appendValue(coordinate).appendText(" contained ").appendValue(actual).appendText(" expected ").appendValue(expected)
+            	.appendText(" sheet ").appendValue(sheet.getSheetName());
             return false;
         }
         return true;

--- a/src/main/java/bad/robot/excel/matchers/CellNumberMatcher.java
+++ b/src/main/java/bad/robot/excel/matchers/CellNumberMatcher.java
@@ -45,7 +45,9 @@ public class CellNumberMatcher extends TypeSafeDiagnosingMatcher<Row> {
                 .appendText(" cell(s) on row ")
                 .appendValue(asExcelRow(expected))
                 .appendText(" expected ")
-                .appendValue(numberOfCellsIn(expected));
+                .appendValue(numberOfCellsIn(expected))
+                .appendText(" sheet ")
+                .appendValue(expected.getSheet().getSheetName());
             return false;
         }
         return true;
@@ -53,7 +55,8 @@ public class CellNumberMatcher extends TypeSafeDiagnosingMatcher<Row> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendValue(numberOfCellsIn(expected)).appendText(" cell(s) on row ").appendValue(asExcelRow(expected));
+        description.appendValue(numberOfCellsIn(expected)).appendText(" cell(s) on row ").appendValue(asExcelRow(expected))
+        	.appendText(" sheet ").appendValue(expected.getSheet().getSheetName());
     }
 
     /** POI is zero-based */

--- a/src/main/java/bad/robot/excel/matchers/CellType.java
+++ b/src/main/java/bad/robot/excel/matchers/CellType.java
@@ -59,6 +59,10 @@ public enum CellType implements CellAdapter {
         public Cell adapt(org.apache.poi.ss.usermodel.Cell cell) {
             if (cell.getHyperlink() != null && containsUrl(cell.getHyperlink()))
                 return new HyperlinkCell(hyperlink(cell.getStringCellValue(), cell.getHyperlink().getAddress()));
+            
+            if (cell.getStringCellValue() == null || "".equals(cell.getStringCellValue()))
+                return new BlankCell();
+            
             return new StringCell(cell.getStringCellValue());
         }
 

--- a/src/main/java/bad/robot/excel/matchers/CellsMatcher.java
+++ b/src/main/java/bad/robot/excel/matchers/CellsMatcher.java
@@ -56,7 +56,7 @@ public class CellsMatcher extends TypeSafeDiagnosingMatcher<Row> {
     private static List<Matcher<Row>> createCellMatchers(Row row) {
         List<Matcher<Row>> matchers = new ArrayList<Matcher<Row>>();
         for (Cell expected : row)
-            matchers.add(hasSameCell(expected));
+            matchers.add(hasSameCell(row.getSheet(), expected));
         return matchers;
     }
 

--- a/src/main/java/bad/robot/excel/matchers/RowMissingMatcher.java
+++ b/src/main/java/bad/robot/excel/matchers/RowMissingMatcher.java
@@ -37,7 +37,8 @@ public class RowMissingMatcher extends TypeSafeDiagnosingMatcher<Row> {
     @Override
     protected boolean matchesSafely(Row actual, Description mismatch) {
         if (actual == null) {
-            mismatch.appendText("row ").appendValue(asExcelRow(expected)).appendText(" is missing");
+            mismatch.appendText("row ").appendValue(asExcelRow(expected)).appendText(" is missing")
+            	.appendText(" in sheet ").appendValue(expected.getSheet().getSheetName());
             return false;
         }
         return true;
@@ -45,6 +46,7 @@ public class RowMissingMatcher extends TypeSafeDiagnosingMatcher<Row> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText("row ").appendValue(asExcelRow(expected)).appendText(" to be present");
+        description.appendText("row ").appendValue(asExcelRow(expected)).appendText(" to be present")
+        	.appendText(" in sheet ").appendValue(expected.getSheet().getSheetName());
     }
 }

--- a/src/test/java/bad/robot/excel/matchers/CellInRowMatcherTest.java
+++ b/src/test/java/bad/robot/excel/matchers/CellInRowMatcherTest.java
@@ -17,6 +17,7 @@
 package bad.robot.excel.matchers;
 
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.hamcrest.StringDescription;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,88 +38,91 @@ public class CellInRowMatcherTest {
 
     private final StringDescription description = new StringDescription();
 
+    private Sheet sheet;
     private Row row;
+
 
     @Before
     public void loadWorkbookAndSheets() throws IOException {
         row = firstRowOf("rowWithVariousCells.xls");
+        sheet = row.getSheet();
     }
 
     @Test
     public void exampleUsage() {
-        assertThat(row, hasSameCell(createCell(0, 6, "Text")));
-        assertThat(row, not(hasSameCell(createCell(0, 6, "XXX"))));
+        assertThat(row, hasSameCell(sheet, createCell(0, 6, "Text")));
+        assertThat(row, not(hasSameCell(sheet, createCell(0, 6, "XXX"))));
     }
 
     @Test
     public void matches() {
-        assertThat(hasSameCell(createBlankCell(0, 0)).matches(row), is(true));
-        assertThat(hasSameCell(createCell(0, 1, true)).matches(row), is(true));
-        assertThat(hasSameCell(createCell(0, 2, (byte) 0x07)).matches(row), is(true));
-        assertThat(hasSameCell(createFormulaCell(0, 3, "2+3")).matches(row), is(true));
-        assertThat(hasSameCell(createCell(0, 4, 34.5D)).matches(row), is(true));
-        assertThat(hasSameCell(createCell(0, 5, createDate(22, AUGUST, 2012))).matches(row), is(true));
-        assertThat(hasSameCell(createCell(0, 6, "Text")).matches(row), is(true));
+        assertThat(hasSameCell(sheet, createBlankCell(0, 0)).matches(row), is(true));
+        assertThat(hasSameCell(sheet, createCell(0, 1, true)).matches(row), is(true));
+        assertThat(hasSameCell(sheet, createCell(0, 2, (byte) 0x07)).matches(row), is(true));
+        assertThat(hasSameCell(sheet, createFormulaCell(0, 3, "2+3")).matches(row), is(true));
+        assertThat(hasSameCell(sheet, createCell(0, 4, 34.5D)).matches(row), is(true));
+        assertThat(hasSameCell(sheet, createCell(0, 5, createDate(22, AUGUST, 2012))).matches(row), is(true));
+        assertThat(hasSameCell(sheet, createCell(0, 6, "Text")).matches(row), is(true));
     }
 
     @Test
     public void doesNotMatch() {
-        assertThat(hasSameCell(createBlankCell(0, 1)).matches(row), is(false));
-        assertThat(hasSameCell(createCell(0, 1, false)).matches(row), is(false));
-        assertThat(hasSameCell(createCell(0, 3, (byte) 0x07)).matches(row), is(false));
-        assertThat(hasSameCell(createFormulaCell(0, 3, "21*3")).matches(row), is(false));
-        assertThat(hasSameCell(createCell(0, 4, 342.5D)).matches(row), is(false));
-        assertThat(hasSameCell(createCell(0, 5, createDate(22, AUGUST, 2011))).matches(row), is(false));
-        assertThat(hasSameCell(createCell(0, 6, "text")).matches(row), is(false));
+        assertThat(hasSameCell(sheet, createBlankCell(0, 1)).matches(row), is(false));
+        assertThat(hasSameCell(sheet, createCell(0, 1, false)).matches(row), is(false));
+        assertThat(hasSameCell(sheet, createCell(0, 3, (byte) 0x07)).matches(row), is(false));
+        assertThat(hasSameCell(sheet, createFormulaCell(0, 3, "21*3")).matches(row), is(false));
+        assertThat(hasSameCell(sheet, createCell(0, 4, 342.5D)).matches(row), is(false));
+        assertThat(hasSameCell(sheet, createCell(0, 5, createDate(22, AUGUST, 2011))).matches(row), is(false));
+        assertThat(hasSameCell(sheet, createCell(0, 6, "text")).matches(row), is(false));
     }
 
     @Test
     public void describe() {
-        hasSameCell(createCell(0, 0, "XXX")).describeTo(description);
+        hasSameCell(sheet, createCell(0, 0, "XXX")).describeTo(description);
         assertThat(description.toString(), is("equality of cell \"A1\""));
     }
 
     @Test
     public void mismatchMissingCell() {
-        hasSameCell(createCell(0, 0, "XXX")).matchesSafely(row, description);
-        assertThat(description.toString(), is("cell at \"A1\" contained <nothing> expected <\"XXX\">"));
+        hasSameCell(sheet, createCell(0, 0, "XXX")).matchesSafely(row, description);
+        assertThat(description.toString(), is("cell at \"A1\" contained <nothing> expected <\"XXX\"> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatchBooleanCell() {
-        hasSameCell(createCell(0, 1, false)).matchesSafely(row, description);
-        assertThat(description.toString(), is("cell at \"B1\" contained <TRUE> expected <FALSE>"));
+        hasSameCell(sheet, createCell(0, 1, false)).matchesSafely(row, description);
+        assertThat(description.toString(), is("cell at \"B1\" contained <TRUE> expected <FALSE> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatchFormulaErrorCell() {
-        hasSameCell(createCell(0, 2, (byte) 0x00)).matchesSafely(row, description);
-        assertThat(description.toString(), is("cell at \"C1\" contained <Error:7> expected <Error:0>"));
+        hasSameCell(sheet, createCell(0, 2, (byte) 0x00)).matchesSafely(row, description);
+        assertThat(description.toString(), is("cell at \"C1\" contained <Error:7> expected <Error:0> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatchFormulaCell() {
-        hasSameCell(createFormulaCell(0, 3, "2+2")).matchesSafely(row, description);
-        assertThat(description.toString(), is("cell at \"D1\" contained <Formula:2+3> expected <Formula:2+2>"));
+        hasSameCell(sheet, createFormulaCell(0, 3, "2+2")).matchesSafely(row, description);
+        assertThat(description.toString(), is("cell at \"D1\" contained <Formula:2+3> expected <Formula:2+2> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatchNumericCell() {
-        hasSameCell(createCell(0, 4, 341.5D)).matchesSafely(row, description);
-        assertThat(description.toString(), is("cell at \"E1\" contained <34.5D> expected <341.5D>"));
+        hasSameCell(sheet, createCell(0, 4, 341.5D)).matchesSafely(row, description);
+        assertThat(description.toString(), is("cell at \"E1\" contained <34.5D> expected <341.5D> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatchDateCell() {
         assertTimezone(is("UTC"));
-        hasSameCell(createCell(0, 5, createDate(21, AUGUST, 2012))).matchesSafely(row, description);
-        assertThat(description.toString(), is("cell at \"F1\" contained <Wed Aug 22 00:00:00 UTC 2012> expected <Tue Aug 21 00:00:00 UTC 2012>"));
+        hasSameCell(sheet, createCell(0, 5, createDate(21, AUGUST, 2012))).matchesSafely(row, description);
+        assertThat(description.toString(), is("cell at \"F1\" contained <Wed Aug 22 00:00:00 UTC 2012> expected <Tue Aug 21 00:00:00 UTC 2012> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatchStringCell() {
-        hasSameCell(createCell(0, 6, "XXX")).matchesSafely(row, description);
-        assertThat(description.toString(), is("cell at \"G1\" contained <\"Text\"> expected <\"XXX\">"));
+        hasSameCell(sheet, createCell(0, 6, "XXX")).matchesSafely(row, description);
+        assertThat(description.toString(), is("cell at \"G1\" contained <\"Text\"> expected <\"XXX\"> sheet \"Sheet1\""));
     }
 
 }

--- a/src/test/java/bad/robot/excel/matchers/CellNumberMatcherTest.java
+++ b/src/test/java/bad/robot/excel/matchers/CellNumberMatcherTest.java
@@ -61,14 +61,14 @@ public class CellNumberMatcherTest {
     public void description() {
         Description description = new StringDescription();
         hasSameNumberOfCellsAs(rowWithThreeCells).describeTo(description);
-        assertThat(description.toString(), is("<3> cell(s) on row <1>"));
+        assertThat(description.toString(), is("<3> cell(s) on row <1> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatch() {
         Description description = new StringDescription();
         hasSameNumberOfCellsAs(rowWithThreeCells).matchesSafely(rowWithTwoCells, description);
-        assertThat(description.toString(), is("got <2> cell(s) on row <1> expected <3>"));
+        assertThat(description.toString(), is("got <2> cell(s) on row <1> expected <3> sheet \"Sheet1\""));
     }
 
 }

--- a/src/test/java/bad/robot/excel/matchers/CellsMatcherTest.java
+++ b/src/test/java/bad/robot/excel/matchers/CellsMatcherTest.java
@@ -78,13 +78,13 @@ public class CellsMatcherTest {
     @Test
     public void mismatch() {
         hasSameCellsAs(firstRow).matchesSafely(firstRowWithAlternateValues, description);
-        assertThat(description.toString(), is("cell at \"B1\" contained <3.14D> expected <\"C2, R1\">"));
+        assertThat(description.toString(), is("cell at \"B1\" contained <3.14D> expected <\"C2, R1\"> sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatchOnMissingCell() {
         hasSameCellsAs(secondRow).matchesSafely(secondRowWithAlternateValues, description);
-        assertThat(description.toString(), is("cell at \"B2\" contained <nothing> expected <\"C2, R2\">"));
+        assertThat(description.toString(), is("cell at \"B2\" contained <nothing> expected <\"C2, R2\"> sheet \"Sheet1\""));
     }
 
     @Test
@@ -92,8 +92,8 @@ public class CellsMatcherTest {
         assertTimezone(is("UTC"));
         hasSameCellsAs(thirdRow).matchesSafely(thirdRowWithAlternateValues, description);
         assertThat(description.toString(), allOf(
-            containsString("cell at \"A3\" contained <Wed Feb 01 00:00:00 UTC 2012> expected <\"C1, R3\">,"),
-            containsString("cell at \"B3\" contained <Formula:2+2> expected <\"C2, R3\">")
+            containsString("cell at \"A3\" contained <Wed Feb 01 00:00:00 UTC 2012> expected <\"C1, R3\"> sheet \"Sheet1\","),
+            containsString("cell at \"B3\" contained <Formula:2+2> expected <\"C2, R3\"> sheet \"Sheet1\"")
         ));
     }
 

--- a/src/test/java/bad/robot/excel/matchers/RowInSheetMatcherTest.java
+++ b/src/test/java/bad/robot/excel/matchers/RowInSheetMatcherTest.java
@@ -70,6 +70,6 @@ public class RowInSheetMatcherTest {
     @Test
     public void mismatch() {
         hasSameRow(firstRowOf(sheetWithThreeCells)).matchesSafely(sheetWithThreeCellsAlternativeValues, description);
-        assertThat(description.toString(), is("cell at \"B1\" contained <3.14D> expected <\"C2, R1\">"));
+        assertThat(description.toString(), is("cell at \"B1\" contained <3.14D> expected <\"C2, R1\"> sheet \"Sheet1\""));
     }
 }

--- a/src/test/java/bad/robot/excel/matchers/RowMissingMatcherTest.java
+++ b/src/test/java/bad/robot/excel/matchers/RowMissingMatcherTest.java
@@ -60,13 +60,13 @@ public class RowMissingMatcherTest {
     @Test
     public void describe() {
         rowIsPresent(sheetWithThreeRows).describeTo(description);
-        assertThat(description.toString(), is("row <3> to be present"));
+        assertThat(description.toString(), is("row <3> to be present in sheet \"Sheet1\""));
     }
 
     @Test
     public void mismatch() {
         rowIsPresent(sheetWithThreeRows).matchesSafely(thirdRow, description);
-        assertThat(description.toString(), is("row <3> is missing"));
+        assertThat(description.toString(), is("row <3> is missing in sheet \"Sheet1\""));
     }
 
 }

--- a/src/test/java/bad/robot/excel/matchers/RowsMatcherTest.java
+++ b/src/test/java/bad/robot/excel/matchers/RowsMatcherTest.java
@@ -75,6 +75,6 @@ public class RowsMatcherTest {
     @Test
     public void mismatchOnMissingRow() {
         hasSameRowsAs(sheetWithThreeRows).matchesSafely(sheetWithTwoRows, description);
-        assertThat(description.toString(), is("row <3> is missing"));
+        assertThat(description.toString(), is("row <3> is missing in sheet \"Sheet1\""));
     }
 }


### PR DESCRIPTION
When a file contains multiple sheets it is difficult to decrypt the message.
Also, comparing empty string with blank cell doesn't make much sense, especially since the formatting is ignored anyway.