### PR TITLE
Removed limit of 702 columns

### DIFF
--- a/src/main/java/bad/robot/excel/column/ColumnIndex.java
+++ b/src/main/java/bad/robot/excel/column/ColumnIndex.java
@@ -24,6 +24,10 @@ public class ColumnIndex extends AbstractValueType<Integer> {
         return new ColumnIndex(index.ordinal());
     }
 
+    public static ColumnIndex column(String index) {
+        return column(ExcelColumnIndex.getColumn(index));
+    }
+
     private ColumnIndex(Integer value) {
         super(value);
     }

--- a/src/main/java/bad/robot/excel/column/ExcelColumnIndex.java
+++ b/src/main/java/bad/robot/excel/column/ExcelColumnIndex.java
@@ -18,9 +18,6 @@ package bad.robot.excel.column;
 
 import org.junit.experimental.categories.Categories.ExcludeCategory;
 
-/**
- * Currently supporting only 702 columns. sorry.
- */
 public class ExcelColumnIndex {
 
 	private int ordinal;
@@ -71,6 +68,7 @@ public class ExcelColumnIndex {
     }
 
     public static int valueOf(String key) {
+    	key = key.toUpperCase();
     	for (ExcelColumnIndex s: getValues()) {
     		if (s.name().equals(key)) {
     			return s.ordinal();
@@ -81,8 +79,9 @@ public class ExcelColumnIndex {
     }
 
     public static ExcelColumnIndex getColumn(String key) {
+    	key = key.toUpperCase();
     	for (ExcelColumnIndex s: getValues()) {
-    		if (s.name().equals(key.toUpperCase())) {
+    		if (s.name().equals(key)) {
     			return s;
     		}
     	}

--- a/src/main/java/bad/robot/excel/column/ExcelColumnIndex.java
+++ b/src/main/java/bad/robot/excel/column/ExcelColumnIndex.java
@@ -16,13 +16,143 @@
 
 package bad.robot.excel.column;
 
+import org.junit.experimental.categories.Categories.ExcludeCategory;
+
 /**
  * Currently supporting only 702 columns. sorry.
  */
-public enum ExcelColumnIndex {
-    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AA, AB, AC, AD, AE, AF, AG, AH, AI, AJ, AK, AL, AM, AN, AO, AP, AQ, AR, AS, AT, AU, AV, AW, AX, AY, AZ, BA, BB, BC, BD, BE, BF, BG, BH, BI, BJ, BK, BL, BM, BN, BO, BP, BQ, BR, BS, BT, BU, BV, BW, BX, BY, BZ, CA, CB, CC, CD, CE, CF, CG, CH, CI, CJ, CK, CL, CM, CN, CO, CP, CQ, CR, CS, CT, CU, CV, CW, CX, CY, CZ, DA, DB, DC, DD, DE, DF, DG, DH, DI, DJ, DK, DL, DM, DN, DO, DP, DQ, DR, DS, DT, DU, DV, DW, DX, DY, DZ, EA, EB, EC, ED, EE, EF, EG, EH, EI, EJ, EK, EL, EM, EN, EO, EP, EQ, ER, ES, ET, EU, EV, EW, EX, EY, EZ, FA, FB, FC, FD, FE, FF, FG, FH, FI, FJ, FK, FL, FM, FN, FO, FP, FQ, FR, FS, FT, FU, FV, FW, FX, FY, FZ, GA, GB, GC, GD, GE, GF, GG, GH, GI, GJ, GK, GL, GM, GN, GO, GP, GQ, GR, GS, GT, GU, GV, GW, GX, GY, GZ, HA, HB, HC, HD, HE, HF, HG, HH, HI, HJ, HK, HL, HM, HN, HO, HP, HQ, HR, HS, HT, HU, HV, HW, HX, HY, HZ, IA, IB, IC, ID, IE, IF, IG, IH, II, IJ, IK, IL, IM, IN, IO, IP, IQ, IR, IS, IT, IU, IV, IW, IX, IY, IZ, JA, JB, JC, JD, JE, JF, JG, JH, JI, JJ, JK, JL, JM, JN, JO, JP, JQ, JR, JS, JT, JU, JV, JW, JX, JY, JZ, KA, KB, KC, KD, KE, KF, KG, KH, KI, KJ, KK, KL, KM, KN, KO, KP, KQ, KR, KS, KT, KU, KV, KW, KX, KY, KZ, LA, LB, LC, LD, LE, LF, LG, LH, LI, LJ, LK, LL, LM, LN, LO, LP, LQ, LR, LS, LT, LU, LV, LW, LX, LY, LZ, MA, MB, MC, MD, ME, MF, MG, MH, MI, MJ, MK, ML, MM, MN, MO, MP, MQ, MR, MS, MT, MU, MV, MW, MX, MY, MZ, NA, NB, NC, ND, NE, NF, NG, NH, NI, NJ, NK, NL, NM, NN, NO, NP, NQ, NR, NS, NT, NU, NV, NW, NX, NY, NZ, OA, OB, OC, OD, OE, OF, OG, OH, OI, OJ, OK, OL, OM, ON, OO, OP, OQ, OR, OS, OT, OU, OV, OW, OX, OY, OZ, PA, PB, PC, PD, PE, PF, PG, PH, PI, PJ, PK, PL, PM, PN, PO, PP, PQ, PR, PS, PT, PU, PV, PW, PX, PY, PZ, QA, QB, QC, QD, QE, QF, QG, QH, QI, QJ, QK, QL, QM, QN, QO, QP, QQ, QR, QS, QT, QU, QV, QW, QX, QY, QZ, RA, RB, RC, RD, RE, RF, RG, RH, RI, RJ, RK, RL, RM, RN, RO, RP, RQ, RR, RS, RT, RU, RV, RW, RX, RY, RZ, SA, SB, SC, SD, SE, SF, SG, SH, SI, SJ, SK, SL, SM, SN, SO, SP, SQ, SR, SS, ST, SU, SV, SW, SX, SY, SZ, TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TQ, TR, TS, TT, TU, TV, TW, TX, TY, TZ, UA, UB, UC, UD, UE, UF, UG, UH, UI, UJ, UK, UL, UM, UN, UO, UP, UQ, UR, US, UT, UU, UV, UW, UX, UY, UZ, VA, VB, VC, VD, VE, VF, VG, VH, VI, VJ, VK, VL, VM, VN, VO, VP, VQ, VR, VS, VT, VU, VV, VW, VX, VY, VZ, WA, WB, WC, WD, WE, WF, WG, WH, WI, WJ, WK, WL, WM, WN, WO, WP, WQ, WR, WS, WT, WU, WV, WW, WX, WY, WZ, XA, XB, XC, XD, XE, XF, XG, XH, XI, XJ, XK, XL, XM, XN, XO, XP, XQ, XR, XS, XT, XU, XV, XW, XX, XY, XZ, YA, YB, YC, YD, YE, YF, YG, YH, YI, YJ, YK, YL, YM, YN, YO, YP, YQ, YR, YS, YT, YU, YV, YW, YX, YY, YZ, ZA, ZB, ZC, ZD, ZE, ZF, ZG, ZH, ZI, ZJ, ZK, ZL, ZM, ZN, ZO, ZP, ZQ, ZR, ZS, ZT, ZU, ZV, ZW, ZX, ZY, ZZ;
+public class ExcelColumnIndex {
+
+	private int ordinal;
+
+	private String value;
+
+	private static ExcelColumnIndex[] values = {};
+
+	private static final int MAX_COLUMNS = 16384;
+
+	private ExcelColumnIndex(int ord, String val) {
+		this.ordinal = ord;
+		this.value = val;
+	}
+
+	public int ordinal() {
+		return this.ordinal;
+	}
+
+	public String name() {
+		return this.value;
+	}
+
+	private static ExcelColumnIndex[] getValues() {
+		if (values.length == 0) {
+			values = new ExcelColumnIndex[MAX_COLUMNS];
+			int cnt = 0;
+			for (String s: ColumnsGenerator.generateColumns(MAX_COLUMNS)) {
+				if (cnt > (MAX_COLUMNS-1)) {
+					break;
+				}
+
+				values[cnt] = new ExcelColumnIndex(cnt, s);
+
+				cnt++;
+			}
+		}
+
+		return values;
+	}
+
+	public static ExcelColumnIndex[] values() {
+		return getValues();
+	}
 
     public static ExcelColumnIndex from(int index) {
-        return ExcelColumnIndex.values()[index];
+        return getValues()[index];
+    }
+
+    public static int valueOf(String key) {
+    	for (ExcelColumnIndex s: getValues()) {
+    		if (s.name().equals(key)) {
+    			return s.ordinal();
+    		}
+    	}
+
+    	throw new IllegalArgumentException("Column with key "+key+" does not exists");
+    }
+
+    public static ExcelColumnIndex getColumn(String key) {
+    	for (ExcelColumnIndex s: getValues()) {
+    		if (s.name().equals(key.toUpperCase())) {
+    			return s;
+    		}
+    	}
+
+    	throw new IllegalArgumentException("Column with key "+key+" does not exists");
+    }
+
+    private static class ColumnsGenerator {
+
+
+    	private static char[] getLetters() {
+    		char letters[] = new char[26];
+
+    		int index = 0;
+    		for (char i='A'; i<= 'Z'; i++) {
+    			letters[index] = i;
+    			index++;
+    		}
+
+    		return letters;
+    	}
+
+    	public static String getColumnByIndex(int index) {
+    		return generateColumns(index+1)[index];
+    	}
+
+    	private static String[] generateColumns(int length) {
+
+    		char characters[] = getLetters();
+    		int charactersLength = characters.length,
+    			callTimes = (int)(length / charactersLength);
+
+    		String generated[] = new String[length+charactersLength];
+
+    		if ((length % charactersLength) != 0)
+    		    callTimes++;
+
+
+    		int currentIndex = 0, skip = 0;
+    		for (int i = 0; i<=callTimes; i++) {
+
+    			if (generated[0] == null) {
+    				for (char j: characters) {
+    					generated[currentIndex] = j+"";
+    					currentIndex ++;
+    				}
+    			} else {
+    				int until = currentIndex,
+    				    from,
+    				    counter = 0;
+
+                    firstFor:
+    				for (from = skip; from < until; from++) {
+    					for (char j: characters) {
+    					    if (currentIndex > (generated.length-1)) {
+    					        break firstFor;
+    					    }
+
+    						generated[currentIndex] = generated[from]+j;
+    						currentIndex++;
+    						counter++;
+    					}
+    				}
+
+    				skip = currentIndex-counter;
+    			}
+
+    		}
+
+    		return generated;
+    	}
     }
 }

--- a/src/main/java/bad/robot/excel/sheet/Coordinate.java
+++ b/src/main/java/bad/robot/excel/sheet/Coordinate.java
@@ -44,6 +44,14 @@ public class Coordinate {
         return new Coordinate(column, row, sheet);
     }
 
+    public static Coordinate coordinate(String column, Integer row, SheetIndex sheet) {
+    	return coordinate(ExcelColumnIndex.getColumn(column), row, sheet);
+    }
+
+    public static Coordinate coordinate(String column, Integer row) {
+    	return coordinate(ExcelColumnIndex.getColumn(column), row, sheet(1));
+    }
+
     private Coordinate(ColumnIndex column, RowIndex row, SheetIndex sheet) {
         this.column = column;
         this.row = row;

--- a/src/main/java/bad/robot/excel/sheet/ExcelCoordinate.java
+++ b/src/main/java/bad/robot/excel/sheet/ExcelCoordinate.java
@@ -32,6 +32,14 @@ public class ExcelCoordinate {
         return new ExcelCoordinate(column, row);
     }
 
+    public static ExcelCoordinate coordinate(String column, int row) {
+        return coordinate(ExcelColumnIndex.getColumn(column), row);
+    }
+
+    public static ExcelCoordinate coordinate(String column, ExcelRowIndex row) {
+    	return coordinate(ExcelColumnIndex.getColumn(column), row);
+    }
+
     public ExcelCoordinate(ExcelColumnIndex column, ExcelRowIndex row) {
         this.column = column;
         this.row = row;

--- a/src/test/java/bad/robot/excel/DateCellTest.java
+++ b/src/test/java/bad/robot/excel/DateCellTest.java
@@ -32,8 +32,7 @@ import java.io.IOException;
 import static bad.robot.excel.DateUtil.createDate;
 import static bad.robot.excel.WorkbookResource.*;
 import static bad.robot.excel.column.ColumnIndex.column;
-import static bad.robot.excel.column.ExcelColumnIndex.A;
-import static bad.robot.excel.column.ExcelColumnIndex.B;
+import static bad.robot.excel.column.ExcelColumnIndex.*;
 import static bad.robot.excel.matchers.CellMatcher.equalTo;
 import static bad.robot.excel.sheet.Coordinate.coordinate;
 import static java.util.Calendar.MARCH;
@@ -50,8 +49,8 @@ public class DateCellTest {
         HSSFWorkbook workbook = new HSSFWorkbook();
         HSSFSheet sheet = workbook.createSheet();
         HSSFRow row = sheet.createRow(0);
-        cell.addTo(row, column(A), workbook);
-        assertThat(getCellDataFormatAtCoordinate(coordinate(A, 1), workbook), is("dd-MMM-yyyy"));
+        cell.addTo(row, column(getColumn("A")), workbook);
+        assertThat(getCellDataFormatAtCoordinate(coordinate(getColumn("A"), 1), workbook), is("dd-MMM-yyyy"));
     }
 
     @Test
@@ -61,20 +60,20 @@ public class DateCellTest {
         HSSFRow row = sheet.createRow(0);
         HSSFCell original = row.createCell(0);
         cell.update(original, workbook);
-        assertThat(getCellDataFormatAtCoordinate(coordinate(A, 1), workbook), is("dd-MMM-yyyy"));
+        assertThat(getCellDataFormatAtCoordinate(coordinate(getColumn("B"), 1), workbook), is("dd-MMM-yyyy"));
     }
 
     @Test
     public void replaceNonDateCellWithACell() throws IOException {
         Workbook workbook = getWorkbook("cellTypes.xls");
         PoiWorkbook sheet = new PoiWorkbook(workbook);
-        Coordinate coordinate = coordinate(B, 2);
+        Coordinate coordinate = coordinate(getColumn("B"), 2);
 
         assertThat(getCellForCoordinate(coordinate, workbook), equalTo(new DoubleCell(1001d)));
         sheet.replaceCell(coordinate, createDate(15, MARCH, 2012));
 
         assertThat(getCellForCoordinate(coordinate, workbook), equalTo(new DateCell(createDate(15, MARCH, 2012))));
         assertThat(getCellDataFormatAtCoordinate(coordinate, workbook), is("dd-MMM-yyyy"));
-        assertThat("should not have affected a shared data format", getCellDataFormatAtCoordinate(coordinate(B, 7), workbook), is("General"));
+        assertThat("should not have affected a shared data format", getCellDataFormatAtCoordinate(coordinate(getColumn("B"), 7), workbook), is("General"));
     }
 }

--- a/src/test/java/bad/robot/excel/DateCellTest.java
+++ b/src/test/java/bad/robot/excel/DateCellTest.java
@@ -49,8 +49,8 @@ public class DateCellTest {
         HSSFWorkbook workbook = new HSSFWorkbook();
         HSSFSheet sheet = workbook.createSheet();
         HSSFRow row = sheet.createRow(0);
-        cell.addTo(row, column(getColumn("A")), workbook);
-        assertThat(getCellDataFormatAtCoordinate(coordinate(getColumn("A"), 1), workbook), is("dd-MMM-yyyy"));
+        cell.addTo(row, column("A"), workbook);
+        assertThat(getCellDataFormatAtCoordinate(coordinate("A", 1), workbook), is("dd-MMM-yyyy"));
     }
 
     @Test
@@ -58,22 +58,22 @@ public class DateCellTest {
         HSSFWorkbook workbook = new HSSFWorkbook();
         HSSFSheet sheet = workbook.createSheet();
         HSSFRow row = sheet.createRow(0);
-        HSSFCell original = row.createCell(0);
+        HSSFCell original = row.createCell(1);
         cell.update(original, workbook);
-        assertThat(getCellDataFormatAtCoordinate(coordinate(getColumn("B"), 1), workbook), is("dd-MMM-yyyy"));
+        assertThat(getCellDataFormatAtCoordinate(coordinate("B", 1), workbook), is("dd-MMM-yyyy"));
     }
 
     @Test
     public void replaceNonDateCellWithACell() throws IOException {
         Workbook workbook = getWorkbook("cellTypes.xls");
         PoiWorkbook sheet = new PoiWorkbook(workbook);
-        Coordinate coordinate = coordinate(getColumn("B"), 2);
+        Coordinate coordinate = coordinate("B", 2);
 
         assertThat(getCellForCoordinate(coordinate, workbook), equalTo(new DoubleCell(1001d)));
         sheet.replaceCell(coordinate, createDate(15, MARCH, 2012));
 
         assertThat(getCellForCoordinate(coordinate, workbook), equalTo(new DateCell(createDate(15, MARCH, 2012))));
         assertThat(getCellDataFormatAtCoordinate(coordinate, workbook), is("dd-MMM-yyyy"));
-        assertThat("should not have affected a shared data format", getCellDataFormatAtCoordinate(coordinate(getColumn("B"), 7), workbook), is("General"));
+        assertThat("should not have affected a shared data format", getCellDataFormatAtCoordinate(coordinate("B", 7), workbook), is("General"));
     }
 }

--- a/src/test/java/bad/robot/excel/column/ExcelColumnIndexTest.java
+++ b/src/test/java/bad/robot/excel/column/ExcelColumnIndexTest.java
@@ -26,17 +26,17 @@ public class ExcelColumnIndexTest {
 
     @Test
     public void convertToIndex() {
-        assertThat(A.ordinal(), is(0));
-        assertThat(B.ordinal(), is(1));
-        assertThat(C.ordinal(), is(2));
-        assertThat(X.ordinal(), is(23));
-        assertThat(Y.ordinal(), is(24));
-        assertThat(Z.ordinal(), is(25));
+        assertThat(getColumn("A").ordinal(), is(0));
+        assertThat(getColumn("B").ordinal(), is(1));
+        assertThat(getColumn("C").ordinal(), is(2));
+        assertThat(getColumn("X").ordinal(), is(23));
+        assertThat(getColumn("Y").ordinal(), is(24));
+        assertThat(getColumn("Z").ordinal(), is(25));
     }
 
     @Test
     public void convertRowCoordinateToExcelRowForExtendedAlphabet() {
-        assertThat(AA.ordinal(),is(26));
-        assertThat(ZZ.ordinal(), is(701));
+        assertThat(getColumn("AA").ordinal(),is(26));
+        assertThat(getColumn("ZZ").ordinal(), is(701));
     }
 }

--- a/src/test/java/bad/robot/excel/matchers/CellTypeTest.java
+++ b/src/test/java/bad/robot/excel/matchers/CellTypeTest.java
@@ -25,8 +25,7 @@ import java.io.IOException;
 
 import static bad.robot.excel.WorkbookResource.getCellForCoordinate;
 import static bad.robot.excel.WorkbookResource.getWorkbook;
-import static bad.robot.excel.column.ExcelColumnIndex.B;
-import static bad.robot.excel.column.ExcelColumnIndex.C;
+import static bad.robot.excel.column.ExcelColumnIndex.*;
 import static bad.robot.excel.matchers.CellType.adaptPoi;
 import static bad.robot.excel.sheet.Coordinate.coordinate;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,47 +43,47 @@ public class CellTypeTest {
 
     @Test
     public void adaptBooleanCell() throws IOException {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 6), workbook)), is(instanceOf(BooleanCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 6), workbook)), is(instanceOf(BooleanCell.class)));
     }
 
     @Test
     public void adaptFormulaCell() throws IOException {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 7), workbook)), is(instanceOf(FormulaCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 7), workbook)), is(instanceOf(FormulaCell.class)));
     }
 
     @Test
     public void adaptFormulaTypeToError() throws IOException {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 8), workbook)), is(instanceOf(ErrorCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 8), workbook)), is(instanceOf(ErrorCell.class)));
     }
 
     @Test
     public void adaptNumericTypeToDoubleCell() throws IOException {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 2), workbook)), is(instanceOf(DoubleCell.class)));
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 3), workbook)), is(instanceOf(DoubleCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 2), workbook)), is(instanceOf(DoubleCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 3), workbook)), is(instanceOf(DoubleCell.class)));
     }
 
     @Test
     public void adaptNumericTypeToDateCell() throws IOException {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 1), workbook)), is(instanceOf(DateCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 1), workbook)), is(instanceOf(DateCell.class)));
     }
 
     @Test
     public void adaptStringCell() throws Exception {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 4), workbook)), is(instanceOf(StringCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 4), workbook)), is(instanceOf(StringCell.class)));
     }
 
     @Test
     public void adaptHyperlinkCell() throws Exception {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 5), workbook)), is(instanceOf(HyperlinkCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 5), workbook)), is(instanceOf(HyperlinkCell.class)));
     }
 
     @Test
     public void adaptInternalLinkCell() throws IOException {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(B, 9), workbook)), is(instanceOf(StringCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("B"), 9), workbook)), is(instanceOf(StringCell.class)));
     }
 
     @Test
     public void adaptBlankCell() throws IOException {
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(C, 1), workbook)), is(instanceOf(BlankCell.class)));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("C"), 1), workbook)), is(instanceOf(BlankCell.class)));
     }
 }

--- a/src/test/java/bad/robot/excel/style/ColourTest.java
+++ b/src/test/java/bad/robot/excel/style/ColourTest.java
@@ -45,9 +45,9 @@ public class ColourTest {
         Cell a2 = new StringCell("Yellow", yellow);
         Workbook workbook = getWorkbook("emptySheet.xlsx");
         PoiWorkbook sheet = new PoiWorkbook(workbook);
-        sheet.replaceCell(coordinate(getColumn("A"), 1), a1);
-        sheet.replaceCell(coordinate(getColumn("A"), 2), a2);
-        sheet.replaceCell(coordinate(getColumn("XFD"), 2), a2); //save on last column
+        sheet.replaceCell(coordinate("A", 1), a1);
+        sheet.replaceCell(coordinate("A", 2), a2);
+        sheet.replaceCell(coordinate("XFD", 2), a2); //save on last column
         OutputWorkbook.writeWorkbookToTemporaryFile(workbook, "exampleOfApplyColours");
     }
 }

--- a/src/test/java/bad/robot/excel/style/ColourTest.java
+++ b/src/test/java/bad/robot/excel/style/ColourTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static bad.robot.excel.WorkbookResource.getWorkbook;
-import static bad.robot.excel.column.ExcelColumnIndex.A;
+import static bad.robot.excel.column.ExcelColumnIndex.*;
 import static bad.robot.excel.sheet.Coordinate.coordinate;
 import static bad.robot.excel.style.Colour.*;
 import static bad.robot.excel.style.Fill.fill;
@@ -45,8 +45,9 @@ public class ColourTest {
         Cell a2 = new StringCell("Yellow", yellow);
         Workbook workbook = getWorkbook("emptySheet.xlsx");
         PoiWorkbook sheet = new PoiWorkbook(workbook);
-        sheet.replaceCell(coordinate(A, 1), a1);
-        sheet.replaceCell(coordinate(A, 2), a2);
+        sheet.replaceCell(coordinate(getColumn("A"), 1), a1);
+        sheet.replaceCell(coordinate(getColumn("A"), 2), a2);
+        sheet.replaceCell(coordinate(getColumn("XFD"), 2), a2); //save on last column
         OutputWorkbook.writeWorkbookToTemporaryFile(workbook, "exampleOfApplyColours");
     }
 }

--- a/src/test/java/bad/robot/excel/style/StyleBuilderTest.java
+++ b/src/test/java/bad/robot/excel/style/StyleBuilderTest.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import static bad.robot.excel.WorkbookResource.getWorkbook;
 import static bad.robot.excel.cell.DataFormat.asTwoDecimalPlacesNumber;
 import static bad.robot.excel.column.ColumnIndex.column;
-import static bad.robot.excel.column.ExcelColumnIndex.A;
+import static bad.robot.excel.column.ExcelColumnIndex.getColumn;
 import static bad.robot.excel.matchers.WorkbookMatcher.sameWorkbook;
 import static bad.robot.excel.style.Border.border;
 import static bad.robot.excel.style.BorderStyle.None;
@@ -51,7 +51,7 @@ public class StyleBuilderTest {
         Cell cell = new DoubleCell(9999.99d, aStyle().with(border).with(numberFormat));
 
         HashMap<ColumnIndex, Cell> columns = new HashMap<ColumnIndex, Cell>();
-        columns.put(column(A), cell);
+        columns.put(column(getColumn("A")), cell);
 
         Row row = new Row(columns);
 

--- a/src/test/java/bad/robot/excel/style/StyleBuilderTest.java
+++ b/src/test/java/bad/robot/excel/style/StyleBuilderTest.java
@@ -51,7 +51,7 @@ public class StyleBuilderTest {
         Cell cell = new DoubleCell(9999.99d, aStyle().with(border).with(numberFormat));
 
         HashMap<ColumnIndex, Cell> columns = new HashMap<ColumnIndex, Cell>();
-        columns.put(column(getColumn("A")), cell);
+        columns.put(column("A"), cell);
 
         Row row = new Row(columns);
 

--- a/src/test/java/bad/robot/excel/workbook/PoiWorkbookTest.java
+++ b/src/test/java/bad/robot/excel/workbook/PoiWorkbookTest.java
@@ -72,25 +72,25 @@ public class PoiWorkbookTest {
 
     @Test
     public void shouldReplaceCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellTemplate.xls")).replaceCell(coordinate(column(getColumn("A")), row(1)), "Hello World");
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellTemplate.xls")).replaceCell(coordinate(column("A"), row(1)), "Hello World");
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceCellTemplateExpected.xls")));
     }
 
     @Test
     public void shouldReplaceDateCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceDateCellTemplate.xls")).replaceCell(coordinate(column(getColumn("A")), row(1)), createDate(22, MAY, 1997));
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceDateCellTemplate.xls")).replaceCell(coordinate(column("A"), row(1)), createDate(22, MAY, 1997));
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceDateCellTemplateExpected.xls")));
     }
 
     @Test
     public void shouldReplaceCellsInComplicatedExample() throws IOException {
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplate.xls"))
-                .replaceCell(coordinate(column(getColumn("C")), row(5)), "Very")
-                .replaceCell(coordinate(column(getColumn("D")), row(11)), "Complicated")
-                .replaceCell(coordinate(column(getColumn("G")), row(3)), "Example")
-                .replaceCell(coordinate(column(getColumn("H")), row(7)), "Of")
-                .replaceCell(coordinate(column(getColumn("J")), row(10)), "Templated")
-                .replaceCell(coordinate(column(getColumn("M")), row(15)), "Spreadsheet");
+                .replaceCell(coordinate(column("C"), row(5)), "Very")
+                .replaceCell(coordinate(column("D"), row(11)), "Complicated")
+                .replaceCell(coordinate(column("G"), row(3)), "Example")
+                .replaceCell(coordinate(column("H"), row(7)), "Of")
+                .replaceCell(coordinate(column("J"), row(10)), "Templated")
+                .replaceCell(coordinate(column("M"), row(15)), "Spreadsheet");
 
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplateExpected.xls")));
     }
@@ -98,12 +98,12 @@ public class PoiWorkbookTest {
     @Test
     public void shouldReplaceCellsInComplicatedAlternateSyntaxExample() throws IOException {
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplate.xls"))
-                .replaceCell(coordinate(getColumn("C"), 5), "Very")
-                .replaceCell(coordinate(getColumn("D"), 11), "Complicated")
-                .replaceCell(coordinate(getColumn("G"), 3), "Example")
-                .replaceCell(coordinate(getColumn("H"), 7), "Of")
-                .replaceCell(coordinate(getColumn("J"), 10), "Templated")
-                .replaceCell(coordinate(getColumn("M"), 15), "Spreadsheet");
+                .replaceCell(coordinate("C", 5), "Very")
+                .replaceCell(coordinate("D", 11), "Complicated")
+                .replaceCell(coordinate("G", 3), "Example")
+                .replaceCell(coordinate("H", 7), "Of")
+                .replaceCell(coordinate("J", 10), "Templated")
+                .replaceCell(coordinate("M", 15), "Spreadsheet");
 
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplateExpected.xls")));
     }
@@ -111,18 +111,18 @@ public class PoiWorkbookTest {
     @Test
     public void shouldAppendRow() throws IOException, ParseException {
         RowBuilder row = aRow()
-                .withString(column(getColumn("A")), "This")
-                .withString(column(getColumn("C")), "Row")
-                .withString(column(getColumn("D")), "was")
-                .withString(column(getColumn("E")), "inserted")
-                .withString(column(getColumn("H")), "here")
-                .withString(column(getColumn("I")), "by")
-                .withString(column(getColumn("J")), "some")
-                .withString(column(getColumn("K")), "smart")
-                .withString(column(getColumn("N")), "Programmer")
-                .withInteger(column(getColumn("L")), 1)
-                .withDate(column(getColumn("P")), createDate(11, FEBRUARY, 1979))
-                .withDouble(column(getColumn("O")), new Double("0.123456789"));
+                .withString(column("A"), "This")
+                .withString(column("C"), "Row")
+                .withString(column("D"), "was")
+                .withString(column("E"), "inserted")
+                .withString(column("H"), "here")
+                .withString(column("I"), "by")
+                .withString(column("J"), "some")
+                .withString(column("K"), "smart")
+                .withString(column("N"), "Programmer")
+                .withInteger(column("L"), 1)
+                .withDate(column("P"), createDate(11, FEBRUARY, 1979))
+                .withDouble(column("O"), new Double("0.123456789"));
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldAppendRowTemplate.xls")).appendRowToFirstSheet(row.build());
 
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldAppendRowTemplateExpected.xls")));
@@ -130,15 +130,15 @@ public class PoiWorkbookTest {
 
     @Test
     public void replaceCellWithSameCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).replaceCell(coordinate(getColumn("B"), 4), "value");
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).replaceCell(coordinate("B", 4), "value");
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("cellTypes.xls")));
     }
 
     @Test
     public void replaceCellWithSameRow() throws IOException {
         RowBuilder row = aRow()
-                .withString(column(getColumn("A")), "String")
-                .withString(column(getColumn("B")), "value");
+                .withString(column("A"), "String")
+                .withString(column("B"), "value");
 
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).appendRowToFirstSheet(row.build());
         assertThat(modified.workbook(), Matchers.sameWorkbook(getWorkbook("replaceCellWithSameRowExpected.xls")));
@@ -146,8 +146,8 @@ public class PoiWorkbookTest {
 
     @Test
     public void replaceThenLoadBlankCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).blankCell(coordinate(getColumn("A"), 1));
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("A"), 1), modified.workbook())), is(instanceOf(BlankCell.class)));
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).blankCell(coordinate("A", 1));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate("A", 1), modified.workbook())), is(instanceOf(BlankCell.class)));
     }
 
 }

--- a/src/test/java/bad/robot/excel/workbook/PoiWorkbookTest.java
+++ b/src/test/java/bad/robot/excel/workbook/PoiWorkbookTest.java
@@ -72,25 +72,25 @@ public class PoiWorkbookTest {
 
     @Test
     public void shouldReplaceCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellTemplate.xls")).replaceCell(coordinate(column(A), row(1)), "Hello World");
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellTemplate.xls")).replaceCell(coordinate(column(getColumn("A")), row(1)), "Hello World");
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceCellTemplateExpected.xls")));
     }
 
     @Test
     public void shouldReplaceDateCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceDateCellTemplate.xls")).replaceCell(coordinate(column(A), row(1)), createDate(22, MAY, 1997));
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceDateCellTemplate.xls")).replaceCell(coordinate(column(getColumn("A")), row(1)), createDate(22, MAY, 1997));
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceDateCellTemplateExpected.xls")));
     }
 
     @Test
     public void shouldReplaceCellsInComplicatedExample() throws IOException {
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplate.xls"))
-                .replaceCell(coordinate(column(C), row(5)), "Very")
-                .replaceCell(coordinate(column(D), row(11)), "Complicated")
-                .replaceCell(coordinate(column(G), row(3)), "Example")
-                .replaceCell(coordinate(column(H), row(7)), "Of")
-                .replaceCell(coordinate(column(J), row(10)), "Templated")
-                .replaceCell(coordinate(column(M), row(15)), "Spreadsheet");
+                .replaceCell(coordinate(column(getColumn("C")), row(5)), "Very")
+                .replaceCell(coordinate(column(getColumn("D")), row(11)), "Complicated")
+                .replaceCell(coordinate(column(getColumn("G")), row(3)), "Example")
+                .replaceCell(coordinate(column(getColumn("H")), row(7)), "Of")
+                .replaceCell(coordinate(column(getColumn("J")), row(10)), "Templated")
+                .replaceCell(coordinate(column(getColumn("M")), row(15)), "Spreadsheet");
 
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplateExpected.xls")));
     }
@@ -98,12 +98,12 @@ public class PoiWorkbookTest {
     @Test
     public void shouldReplaceCellsInComplicatedAlternateSyntaxExample() throws IOException {
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplate.xls"))
-                .replaceCell(coordinate(C, 5), "Very")
-                .replaceCell(coordinate(D, 11), "Complicated")
-                .replaceCell(coordinate(G, 3), "Example")
-                .replaceCell(coordinate(H, 7), "Of")
-                .replaceCell(coordinate(J, 10), "Templated")
-                .replaceCell(coordinate(M, 15), "Spreadsheet");
+                .replaceCell(coordinate(getColumn("C"), 5), "Very")
+                .replaceCell(coordinate(getColumn("D"), 11), "Complicated")
+                .replaceCell(coordinate(getColumn("G"), 3), "Example")
+                .replaceCell(coordinate(getColumn("H"), 7), "Of")
+                .replaceCell(coordinate(getColumn("J"), 10), "Templated")
+                .replaceCell(coordinate(getColumn("M"), 15), "Spreadsheet");
 
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldReplaceCellsInComplicatedExampleTemplateExpected.xls")));
     }
@@ -111,18 +111,18 @@ public class PoiWorkbookTest {
     @Test
     public void shouldAppendRow() throws IOException, ParseException {
         RowBuilder row = aRow()
-                .withString(column(A), "This")
-                .withString(column(C), "Row")
-                .withString(column(D), "was")
-                .withString(column(E), "inserted")
-                .withString(column(H), "here")
-                .withString(column(I), "by")
-                .withString(column(J), "some")
-                .withString(column(K), "smart")
-                .withString(column(N), "Programmer")
-                .withInteger(column(L), 1)
-                .withDate(column(P), createDate(11, FEBRUARY, 1979))
-                .withDouble(column(O), new Double("0.123456789"));
+                .withString(column(getColumn("A")), "This")
+                .withString(column(getColumn("C")), "Row")
+                .withString(column(getColumn("D")), "was")
+                .withString(column(getColumn("E")), "inserted")
+                .withString(column(getColumn("H")), "here")
+                .withString(column(getColumn("I")), "by")
+                .withString(column(getColumn("J")), "some")
+                .withString(column(getColumn("K")), "smart")
+                .withString(column(getColumn("N")), "Programmer")
+                .withInteger(column(getColumn("L")), 1)
+                .withDate(column(getColumn("P")), createDate(11, FEBRUARY, 1979))
+                .withDouble(column(getColumn("O")), new Double("0.123456789"));
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("shouldAppendRowTemplate.xls")).appendRowToFirstSheet(row.build());
 
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("shouldAppendRowTemplateExpected.xls")));
@@ -130,15 +130,15 @@ public class PoiWorkbookTest {
 
     @Test
     public void replaceCellWithSameCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).replaceCell(coordinate(B, 4), "value");
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).replaceCell(coordinate(getColumn("B"), 4), "value");
         assertThat(modified.workbook(), sameWorkbook(getWorkbook("cellTypes.xls")));
     }
 
     @Test
     public void replaceCellWithSameRow() throws IOException {
         RowBuilder row = aRow()
-                .withString(column(A), "String")
-                .withString(column(B), "value");
+                .withString(column(getColumn("A")), "String")
+                .withString(column(getColumn("B")), "value");
 
         PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).appendRowToFirstSheet(row.build());
         assertThat(modified.workbook(), Matchers.sameWorkbook(getWorkbook("replaceCellWithSameRowExpected.xls")));
@@ -146,8 +146,8 @@ public class PoiWorkbookTest {
 
     @Test
     public void replaceThenLoadBlankCell() throws IOException {
-        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).blankCell(coordinate(A, 1));
-        assertThat(adaptPoi(getCellForCoordinate(coordinate(A, 1), modified.workbook())), is(instanceOf(BlankCell.class)));
+        PoiWorkbook modified = new PoiWorkbook(getWorkbook("cellTypes.xls")).blankCell(coordinate(getColumn("A"), 1));
+        assertThat(adaptPoi(getCellForCoordinate(coordinate(getColumn("A"), 1), modified.workbook())), is(instanceOf(BlankCell.class)));
     }
 
 }


### PR DESCRIPTION
Max number of columns is 16384, so ExcelColumnIndex is changed a little
bit now you can use any column you want (< 16384) when this number
increases just change MAX_COLUMNS constant and new columns will be
automatically generated
